### PR TITLE
feat:deactivate_twilo

### DIFF
--- a/frontend/src/components/SafeBridgeApp.tsx
+++ b/frontend/src/components/SafeBridgeApp.tsx
@@ -396,11 +396,14 @@ export const SafeBridgeApp: React.FC = () => {
       }
       await fetchRoutePaths(uniqueHospitals, { updateDistances: true });
 
-      if (uniqueHospitals.length > 0) {
-        setTwilioAutoCalling(true);
-      } else {
-        setTwilioAutoCalling(false);
-      }
+      // [자동 전화 기능 - 필요시 주석 해제]
+      // 실제 Twilio 전화 기능은 테스트 완료. 테스트 환경에서는 수동 버튼 사용.
+      // if (uniqueHospitals.length > 0) {
+      //   setTwilioAutoCalling(true); // Start auto-calling
+      // } else {
+      //   setTwilioAutoCalling(false);
+      // }
+      setTwilioAutoCalling(false); // 테스트 환경: 자동 전화 비활성화
     } catch (error: any) {
       console.error("병원 조회 오류:", error);
       alert(error.message || "병원 조회 중 오류가 발생했습니다. 백엔드 서버가 실행 중인지 확인해주세요.");
@@ -682,6 +685,8 @@ export const SafeBridgeApp: React.FC = () => {
     return pieces.filter(Boolean).join(" ");
   };
 
+  // [실제 Twilio 전화 기능 - 필요시 주석 해제하여 사용]
+  // 실제 Twilio 전화 기능은 테스트 완료. 테스트 환경에서는 수동 버튼 사용.
   const handleStartTwilioCall = async (hospital: Hospital) => {
     // 모든 자동 전화는 지정된 안전 테스트 번호로 우회
     try {
@@ -768,26 +773,27 @@ export const SafeBridgeApp: React.FC = () => {
   }, [hospitals, activeCalls, hospitalApprovalStatus]);
 
 
-  // Twilio 자동 전화 로직
-  useEffect(() => {
-    if (!twilioAutoCalling || approvedHospital || currentHospitalIndex >= hospitals.length) {
-      return;
-    }
-
-    const currentHospital = hospitals[currentHospitalIndex];
-    if (!currentHospital) return;
-
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    if (!activeCalls[currentHospital.hpid || ""]) {
-      timer = setTimeout(() => {
-        handleStartTwilioCall(currentHospital);
-      }, 10000);
-    }
-    return () => {
-      if (timer) clearTimeout(timer);
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [twilioAutoCalling, currentHospitalIndex, hospitals.length, approvedHospital, activeCalls]);
+  // [자동 전화 기능 - 필요시 주석 해제]
+  // 실제 Twilio 전화 기능은 테스트 완료. 테스트 환경에서는 수동 버튼 사용.
+  // useEffect(() => {
+  //   if (!twilioAutoCalling || approvedHospital || currentHospitalIndex >= hospitals.length) {
+  //     return;
+  //   }
+  //
+  //   const currentHospital = hospitals[currentHospitalIndex];
+  //   if (!currentHospital) return;
+  //
+  //   let timer: ReturnType<typeof setTimeout> | null = null;
+  //   if (!activeCalls[currentHospital.hpid || ""]) {
+  //     timer = setTimeout(() => {
+  //       handleStartTwilioCall(currentHospital);
+  //     }, 10000);
+  //   }
+  //   return () => {
+  //     if (timer) clearTimeout(timer);
+  //   };
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [twilioAutoCalling, currentHospitalIndex, hospitals.length, approvedHospital, activeCalls]);
 
   useEffect(() => {
     if (twilioAutoCalling && !hasCallableHospital) {


### PR DESCRIPTION
변경 사항 요약

1. 자동 전화 기능 주석 처리
병원 검색 후 자동 전화 시작 부분 주석 처리 (399-403줄)
자동 전화 트리거 useEffect 주석 처리 (772-790줄)
handleStartTwilioCall 함수는 유지 (나중에 사용 가능)

2. 수동 버튼 활성화
HospitalCard에 수락/거절 버튼이 이미 구현되어 있음
canInteract={!approvedHospital} 조건으로 승인된 병원이 없을 때 버튼 활성화
각 병원 카드에 다음 버튼 표시:
수용 확정 (초록색)
수용 불가 (빨간색)
ARS 재요청 (파란색) - 실제 전화 기능 테스트용

3. 테스트 환경 구성
자동 전화는 비활성화되어 수동 테스트 가능
필요 시 주석을 해제해 자동 전화 기능 재활성화 가능
실제 Twilio 전화 기능은 그대로 유지되어 "ARS 재요청" 버튼으로 테스트 가능
이제 병원 검색 후 각 병원 카드의 수락/거절 버튼을 수동으로 클릭해 테스트할 수 있습니다.